### PR TITLE
upgrade the jar version referenced in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     - 9382
     # TODO: Either omit version from JAR name or pass as ENV variable
     # TODO: Set heap size somewhere besides the command line argument?
-    command: java -Xmx10000m -cp amod-1.4.8.jar amod.aido.AidoHost
+    command: java -Xmx10000m -cp amod-1.5.7.jar amod.aido.AidoHost
   aido-guest:
     build: .
     image: duckietown/amod
     links:
       - aido-host
-    command: java -Xmx10000m -cp amod-1.4.8.jar amod.aido.demo.AidoGuest aido-host
+    command: java -Xmx10000m -cp amod-1.5.7.jar amod.aido.demo.AidoGuest aido-host


### PR DESCRIPTION
upgrade the jar version referenced in docker-compose to match the pom.xml file's version

otherwise, docker-compose up fails to start up with

> aido-host_1   | Error: Could not find or load main class amod.aido.AidoHost
amod_aido-host_1 exited with code 1
aido-guest_1  | Error: Could not find or load main class amod.aido.demo.AidoGuest
amod_aido-guest_1 exited with code 1